### PR TITLE
Format and lint YAML files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,17 @@
+---
 version: 2
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  open-pull-requests-limit: 9999
-  schedule:
-    interval: weekly
-  assignees:
-    - marekdedic
-- package-ecosystem: npm
-  directory: "/"
-  open-pull-requests-limit: 9999
-  schedule:
-    interval: weekly
-  assignees:
-    - marekdedic
+  - package-ecosystem: github-actions
+    directory: "/"
+    open-pull-requests-limit: 9999
+    schedule:
+      interval: weekly
+    assignees:
+      - marekdedic
+  - package-ecosystem: npm
+    directory: "/"
+    open-pull-requests-limit: 9999
+    schedule:
+      interval: weekly
+    assignees:
+      - marekdedic

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,6 @@
+---
 name: "CI"
-on:
+"on":
   push:
     branches: "*"
   pull_request:
@@ -19,7 +20,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: "~/.npm"
-          key: npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
+          key: >-
+            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{
+            hashFiles('package.json') }}
           restore-keys: |
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-
@@ -92,7 +95,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: "~/.npm"
-          key: npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
+          key: >-
+            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{
+            hashFiles('package.json') }}
           restore-keys: |
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,6 @@
+---
 name: "Dependabot auto-merge"
-on: "pull_request_target"
+"on": "pull_request_target"
 
 permissions:
   pull-requests: write
@@ -13,12 +14,14 @@ jobs:
     steps:
       - name: "Fetch Dependabot metadata"
         id: "metadata"
-        uses: dependabot/fetch-metadata@v2.5.0
+        uses: dependabot/fetch-metadata@v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Enable auto-merge for the request"
-        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        if: >-
+          ${{ steps.metadata.outputs.update-type !=
+          'version-update:semver-major' }}
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,6 @@
+---
 name: "Publish"
-on:
+"on":
   release:
     types: [published]
 
@@ -31,7 +32,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: "~/.npm"
-          key: npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
+          key: >-
+            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{
+            hashFiles('package.json') }}
           restore-keys: |
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-


### PR DESCRIPTION
Conform every YAML file in the repository to yamllint's default rules,
which previously reported a large number of issues:

- Add the `---` document start marker.
- Quote the `on:` workflow key so it is not parsed as the boolean true.
- Indent block sequences under their parent key, which was previously
  inconsistent even within a single file.
- Fold over-long values into `>-` block scalars. Every folded value is
  preserved byte for byte.

Beyond formatting:

- Bump dependabot/fetch-metadata from v2.5.0 to v3.1.0, matching the
  version already used in the other repositories.

Verified by comparing every file before and after as parsed YAML: apart
from the changes listed above, no key or value differs. The remaining
long lines are `restore-keys` entries and shell lines inside `run: |`
blocks, which cannot be wrapped without changing their meaning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)