### PR TITLE
Migrate coverage reporting from Coveralls to Codecov

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,19 +70,10 @@ jobs:
           npm run test-coverage
 
       - name: "Upload coverage results"
-        uses: coverallsapp/github-action@v2.3.8
+        uses: codecov/codecov-action@v7.0.0
         with:
-          parallel: true
-
-  close-coverage:
-    name: "Close parallel coverage"
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - name: "Close parallel coverage"
-        uses: coverallsapp/github-action@v2.3.8
-        with:
-          parallel-finished: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
 
   lint:
     name: "Lint"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM Version](https://img.shields.io/npm/v/rollup-plugin-htaccess?logo=npm)](https://www.npmjs.com/package/rollup-plugin-htaccess)
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/marekdedic/rollup-plugin-htaccess/CI.yml?branch=master&logo=github)](https://github.com/marekdedic/rollup-plugin-htaccess/actions)
-[![Coveralls](https://img.shields.io/coverallsCoverage/github/marekdedic/rollup-plugin-htaccess?branch=master&logo=coveralls)](https://coveralls.io/github/marekdedic/rollup-plugin-htaccess)
+[![Codecov (with branch)](https://img.shields.io/codecov/c/github/marekdedic/rollup-plugin-htaccess/master?logo=codecov)](https://app.codecov.io/gh/marekdedic/rollup-plugin-htaccess)
 [![NPM Downloads](https://img.shields.io/npm/dm/rollup-plugin-htaccess?logo=npm)](https://www.npmjs.com/package/rollup-plugin-htaccess)
 [![NPM License](https://img.shields.io/npm/l/rollup-plugin-htaccess)](https://github.com/marekdedic/rollup-plugin-htaccess/blob/master/LICENSE)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,24 @@
+---
+coverage:
+  range: "95...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      default:
+        target: 90%
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: true
+      loop: true
+      method: false
+      macro: false
+
+comment:
+  layout: "reach,diff,flags,files"
+  require_changes: false


### PR DESCRIPTION
Unify coverage reporting on Codecov, which the other repositories already
use, so that all of them report to a single service.

- Replace `coverallsapp/github-action` with `codecov/codecov-action`,
  configured as in the other repositories: an authentication token from
  `secrets.CODECOV_TOKEN` and `fail_ci_if_error: true`.
- Add `codecov.yml`, identical to the one in the other repositories.
- Point the README coverage badge at Codecov.
- Drop the `close-coverage` job. Coveralls needed the parallel uploads from
  the test matrix to be explicitly finalised; Codecov merges the uploads of
  a commit on its own, so no such job is needed.

> [!IMPORTANT]
> This repository has no `CODECOV_TOKEN` secret yet. It needs to be added
> (Codecov → repository settings) before merging, otherwise the upload step
> fails and, because of `fail_ci_if_error: true`, takes CI down with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)