### PR TITLE
Don't count test helpers in coverage

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    coverage: {
+      exclude: ["tests/**"],
+    },
     mockReset: true,
   },
 });


### PR DESCRIPTION
The tests directory was being measured as if it were production code.
Vitest's default `coverage.exclude` matches test *file name* patterns
(`**/*.{test,spec}.*`) rather than test *directories*, so files under
`tests/` that don't carry `.test.` in their name were instrumented, because
the tests import them.

In this repository 150 of the 176 measured files were the option fixtures
under `tests/specs/`, accounting for roughly 30 % of the measured lines — by
far the largest case, with test data outnumbering product code six to one.

Exclude `tests/**` from coverage. Doing this in the vitest config rather than
through `codecov.yml`'s `ignore` key keeps a local `npm run test-coverage` run
consistent with CI, and leaves `codecov.yml` byte-identical across all the
repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)