### PR TITLE
Use npm 11 in the test job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,6 +57,10 @@ jobs:
           node-version: ${{ matrix.versions.node }}
           cache: 'npm'
 
+      - name: "Update NPM"
+        run: |
+          npm install -g npm@11
+
       - name: "Install NPM dependencies"
         run: |
           npm install


### PR DESCRIPTION
The test matrix runs a second `npm install` to override the rolldown, rollup and vite versions. On the Node 20 rows, that install crashes:

```
npm error Cannot read properties of null (reading 'edgesOut')
```

The crash is a bug in npm 10's Arborist peer resolver (`#loadPeerSet` in `build-ideal-tree.js`), hit while walking vitest's optional peer graph (`vitest` → `@vitejs/devtools-*` → `jsdom` → `canvas`). It is not a dependency conflict — the same tree resolves cleanly under npm 11, and reproduces reliably under npm 10.9.4 on a clean checkout of `master`. Node 20 is the only matrix row that still ships npm 10, which is why only those rows fail (the others show as failed only because `fail-fast` cancels them).

Install npm 11 before the dependency steps so every row resolves with a version that doesn't crash, rather than weakening peer resolution with `--legacy-peer-deps`.